### PR TITLE
Add step to create D1 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,25 @@ A lightweight, API-first backend for products, inventory, checkout, and ordersâ€
 git clone https://github.com/ygwyg/merchant
 cd merchant && npm install
 
-# 2. Initialize (creates store + API keys)
+# 2. Create D1 database
+npx wrangler d1 create merchant-db --binding "DB"
+
+# 3. Initialize (creates store + API keys)
 npx tsx scripts/init.ts
 
-# 3. Start the API
+# 4. Start the API
 npm run dev
 
-# 4. Seed demo data (optional)
+# 5. Seed demo data (optional)
 npx tsx scripts/seed.ts http://localhost:8787 sk_your_admin_key
 
-# 5. Connect Stripe
+# 6. Connect Stripe
 curl -X POST http://localhost:8787/v1/setup/stripe \
   -H "Authorization: Bearer sk_your_admin_key" \
   -H "Content-Type: application/json" \
   -d '{"stripe_secret_key":"sk_test_..."}'
 
-# 6. Admin dashboard
+# 7. Admin dashboard
 cd admin && npm install && npm run dev
 ```
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -3,11 +3,7 @@
   "main": "src/index.ts",
   "compatibility_date": "2025-12-01",
 
-  "d1_databases": [
-    {
-      "binding": "DB"
-    }
-  ],
+  "d1_databases": [],
 
   "r2_buckets": [
     {


### PR DESCRIPTION
A D1 database needs to exist before running `npx tsx scripts/init.ts`. I added a step in the README to include this instruction. An alternative option would be to create run the command from the actual `init.ts` script.

<img width="1640" height="522" alt="Image 2025-12-30 at 23 23 44@2x" src="https://github.com/user-attachments/assets/2ddfc7ed-1ab3-4422-a221-e7c785692681" />
